### PR TITLE
Version 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ tspex is a Python package for calculating tissue-specificity metrics from gene e
 tspex features include:
   - An easy-to-use object-oriented interface.
   - Twelve different tissue-specificity metrics.
-  - A plotting function.
+  - Integration with pandas.
+  - Graphing functions.
   - Support for Jupyter notebooks.
 
 ## Installation

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tspex',
-    version='0.1.1',
+    version='0.2.0',
     packages=find_packages(),
     license='GNU General Public License v3.0',
     description='A Python package for calculating tissue-specificity metrics for gene expression.',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     description='A Python package for calculating tissue-specificity metrics for gene expression.',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    install_requires=['matplotlib', 'numpy', 'pandas >= 0.23'],
+    install_requires=['matplotlib >= 2.2', 'numpy', 'pandas >= 0.23'],
     python_requires= '>=3',
     url='https://github.com/apcamargo/tspex',
     keywords=['bioinformatics', 'gene expression', 'tissue-specificity', 'transcriptomics'],

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -160,13 +160,16 @@ class TissueSpecificity:
         im = ax.imshow(expr_data, cmap='viridis', aspect='auto')
         ax.set_ylabel('Genes')
         ax.set_xlabel('Tissues')
-        plt.yticks(np.arange(0, len(expr_data.index), 1), expr_data.index)
-        plt.xticks(np.arange(0, len(expr_data.columns), 1), expr_data.columns)
-        plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
-        cbar = plt.colorbar(im, ax=ax)
-        cbar.ax.set_ylabel(ylabel="Expression", rotation=-90, va="bottom")
-        plt.show()
-						
+        ax.set_yticks(np.arange(0, len(expr_data.index), 1))
+        ax.set_yticklabels(expr_data.index)
+        ax.set_xticks(np.arange(0, len(expr_data.columns), 1))
+        ax.set_xticklabels(expr_data.columns)
+        ax.tick_params(length=0)
+        ax.tick_params(axis='x', rotation=45)
+        cbar = fig.colorbar(im, ax=ax, pad=0.005, aspect=30)
+        cbar.ax.set_ylabel(ylabel='Expression', rotation=-90, va='bottom')
+        cbar.ax.tick_params(length=0)
+
     def to_file(self, filename):
         """
         Write the tissue-specificity values into a tab-separated values (tsv)

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -167,10 +167,11 @@ class TissueSpecificity:
         else:
             ts_data = self.tissue_specificity
         expr_data = self.expression_data.loc[ts_data >= threshold]
+        if not len(expr_data):
+            warnings.warn('There is no gene with tissue-specificity value above the threshold.')
+            return None
         if use_zscore:
             expr_data = expr_data.apply(zscore, axis=1, result_type='broadcast', transform=False)
-        if not len(expr_data):
-            warnings.warn('There is no gene with tissue-specificity value over the threshold.')
         fig, ax = plt.subplots(figsize=size, dpi=dpi, constrained_layout=True)
         im = ax.imshow(expr_data, cmap=cmap, aspect='auto')
         ax.set_ylabel('Genes')

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -107,8 +107,7 @@ class TissueSpecificity:
         tissue_specificity = tissue_specificity.round(4)
         return tissue_specificity
 
-
-    def histogram(self, bins=50, size=(7,4), dpi=100):
+    def plot_histogram(self, bins=50, size=(7, 4), dpi=100):
         """
         Plot a histogram of the tissue-specificity values. If the chosen metric
         is one of 'zscore', 'spm' or 'js_specificity', the maximum row value is used
@@ -135,7 +134,7 @@ class TissueSpecificity:
             ax.set_xlabel(self._method)
             ax.set_title('Histogram of {} values'.format(self._method), loc='left')
 
-    def heatmap(self, threshold, size=(5, 5), dpi=100):
+    def plot_heatmap(self, threshold, size=(7, 4), dpi=100):
         """
         Plot a heatmap of gene expression values, given a tissue-specificity threshold.
         The threshold should be in the [0,1] range.
@@ -146,7 +145,7 @@ class TissueSpecificity:
         ----------
         threshold : float, default None
             Threshold of gene tissue-specificity.
-        size : tuple, default (5,5)
+        size : tuple, default (7,4)
             Size of the figure.
         dpi : int, default 100
             The resolution in dots per inch.

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -87,11 +87,11 @@ class TissueSpecificity:
             'js_specificity': js_specificity,
             'js_specificity_dpm': js_specificity_dpm
         }
+        self.expression_data = expression_data.astype('float')
+        if np.any(self.expression_data < 0):
+            raise ValueError('Negative expression values are not allowed.')
         if log:
-            self.expression_data = expression_data.astype('float')
             self.expression_data = self.expression_data.apply(lambda x: np.log(x+1))
-        else:
-            self.expression_data = expression_data.astype('float')
         self._method = str(method)
         self._transform = kwargs.pop('transform', True)
         self._threshold = kwargs.pop('threshold', 0)

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -128,7 +128,7 @@ class TissueSpecificity:
                 data = self.tissue_specificity.max(axis=1).values
             else:
                 data = self.tissue_specificity.values
-            fig, ax = plt.subplots(figsize=size, dpi=dpi)
+            fig, ax = plt.subplots(figsize=size, dpi=dpi, constrained_layout=True)
             ax.hist(data, bins=bins, alpha=0.85, color='#262626')
             ax.set_ylabel('Number of genes')
             ax.set_xlabel(self._method)

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -193,19 +193,6 @@ class TissueSpecificity:
             cbar.ax.set_ylabel(ylabel='Expression', rotation=-90, va='bottom')
         cbar.ax.tick_params(length=0)
 
-    def to_file(self, filename):
-        """
-        Write the tissue-specificity values into a tab-separated values (tsv)
-        file.
-
-        Parameters
-        ----------
-        filename : str
-            A string containing a path to a filename.
-        """
-
-        self.tissue_specificity.to_csv(filename, sep='\t')
-
     def _repr_html_(self):
         if isinstance(self.tissue_specificity, pd.core.frame.DataFrame):
             return self.tissue_specificity._repr_html_()

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -22,6 +22,8 @@
 TissueSpecificity class of the tspex library.
 """
 
+import warnings
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -134,17 +134,21 @@ class TissueSpecificity:
             ax.set_xlabel(self._method)
             ax.set_title('Histogram of {} values'.format(self._method), loc='left')
 
-    def plot_heatmap(self, threshold, size=(7, 4), dpi=100):
+    def plot_heatmap(self, threshold, gene_names=True, tissue_names=True, size=(7, 4), dpi=100):
         """
-        Plot a heatmap of gene expression values, given a tissue-specificity threshold.
-        The threshold should be in the [0,1] range.
-        If the chosen metric is one of 'zscore', 'spm' or 'js_specificity', the maximum row value
-        is used as a representative of the gene tissue-specificity.
+        Plot a heatmap of the expression of genes with tissue-specificity over a
+        given a threshold. The threshold should be in the [0,1] range. If the
+        chosen metric is one of 'zscore', 'spm' or 'js_specificity', the maximum
+        row value is used as a representative of the gene tissue-specificity.
 
         Parameters
         ----------
         threshold : float, default None
-            Threshold of gene tissue-specificity.
+            Tissue-specificity threshold.
+        gene_names : bool, default True
+            Show gene names in the y-axis.
+        tissue_names : bool, default True
+            Show tissue names in the x-axis.
         size : tuple, default (7,4)
             Size of the figure.
         dpi : int, default 100
@@ -166,6 +170,10 @@ class TissueSpecificity:
         ax.set_xticklabels(expr_data.columns)
         ax.tick_params(length=0)
         ax.tick_params(axis='x', rotation=45)
+        if not gene_names:
+            ax.tick_params(labelleft=False)
+        if not tissue_names:
+            ax.tick_params(labelbottom=False)
         cbar = fig.colorbar(im, ax=ax, pad=0.005, aspect=30)
         cbar.ax.set_ylabel(ylabel='Expression', rotation=-90, va='bottom')
         cbar.ax.tick_params(length=0)

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -157,7 +157,7 @@ class TissueSpecificity:
             ts_data = self.tissue_specificity
         expr_data = self.expression_data.loc[ts_data >= threshold]
         fig, ax = plt.subplots(figsize=size, dpi=dpi, constrained_layout=True)
-        im = ax.imshow(expr_data, cmap="viridis")
+        im = ax.imshow(expr_data, cmap='viridis', aspect='auto')
         ax.set_ylabel('Genes')
         ax.set_xlabel('Tissues')
         plt.yticks(np.arange(0, len(expr_data.index), 1), expr_data.index)

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -167,6 +167,8 @@ class TissueSpecificity:
         expr_data = self.expression_data.loc[ts_data >= threshold]
         if use_zscore:
             expr_data = expr_data.apply(zscore, axis=1, result_type='broadcast', transform=False)
+        if not len(expr_data):
+            warnings.warn('There is no gene with tissue-specificity value over the threshold.')
         fig, ax = plt.subplots(figsize=size, dpi=dpi, constrained_layout=True)
         im = ax.imshow(expr_data, cmap=cmap, aspect='auto')
         ax.set_ylabel('Genes')

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -135,7 +135,39 @@ class TissueSpecificity:
             ax.set_xlabel(self._method)
             ax.set_title('Histogram of {} values'.format(self._method), loc='left')
 
+    def heatmap(self, threshold, size=(5, 5), dpi=100):
+        """
+        Plot a heatmap of gene expression values, given a tissue-specificity threshold.
+        The threshold should be in the [0,1] range.
+        If the chosen metric is one of 'zscore', 'spm' or 'js_specificity', the maximum row value
+        is used as a representative of the gene tissue-specificity.
 
+        Parameters
+        ----------
+        threshold : float, default None
+            Threshold of gene tissue-specificity.
+        size : tuple, default (5,5)
+            Size of the figure.
+        dpi : int, default 100
+            The resolution in dots per inch.
+        """
+
+        if self._method in ['zscore', 'spm', 'js_specificity']:
+            ts_data = self.tissue_specificity.max(axis=1)
+        else:
+            ts_data = self.tissue_specificity
+        expr_data = self.expression_data.loc[ts_data >= threshold]
+        fig, ax = plt.subplots(figsize=size, dpi=dpi, constrained_layout=True)
+        im = ax.imshow(expr_data, cmap="viridis")
+        ax.set_ylabel('Genes')
+        ax.set_xlabel('Tissues')
+        plt.yticks(np.arange(0, len(expr_data.index), 1), expr_data.index)
+        plt.xticks(np.arange(0, len(expr_data.columns), 1), expr_data.columns)
+        plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
+        cbar = plt.colorbar(im, ax=ax)
+        cbar.ax.set_ylabel(ylabel="Expression", rotation=-90, va="bottom")
+        plt.show()
+						
     def to_file(self, filename):
         """
         Write the tissue-specificity values into a tab-separated values (tsv)

--- a/tspex/core/specificity_class.py
+++ b/tspex/core/specificity_class.py
@@ -108,7 +108,7 @@ class TissueSpecificity:
         return tissue_specificity
 
 
-    def tspex_plot(self, bins=30, size=(7,4), dpi=100):
+    def histogram(self, bins=50, size=(7,4), dpi=100):
         """
         Plot a histogram of the tissue-specificity values. If the chosen metric
         is one of 'zscore', 'spm' or 'js_specificity', the maximum row value is used
@@ -116,7 +116,7 @@ class TissueSpecificity:
 
         Parameters
         ----------
-        bins : int, default 30
+        bins : int, default 50
             Number of bins in the histogram.
         size : tuple, default (7,4)
             Size of the figure.


### PR DESCRIPTION
- Changed the name of the `tspex_plot` method to `plot_histogram`.
- Use the `constrained_layout` argument in the `plot_histogram` method.
- Added the `plot_heatmap` method.
- Raise an error in case the user tries to create a `TissueSpecificity` object with a matrix containing negative values.
- Deprecated the `to_file` method in favor of using the native pandas methods.